### PR TITLE
fix: bump golang version to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM alpine:3.22 AS certs
 
 RUN apk add -U --no-cache ca-certificates
 
-FROM golang:1.25.0-alpine3.22 AS helper
+FROM golang:1.25.5-alpine3.22 AS helper
 
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin
 
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@79ad5557681c631ff7f9391a561609a8452f81c1
 
-FROM golang:1.25.0-alpine3.22 AS build
+FROM golang:1.25.5-alpine3.22 AS build
 
 WORKDIR /work
 


### PR DESCRIPTION
Fixes the following vulns

CVE-2025-61723
CVE-2025-61725
CVE-2025-58185
CVE-2025-58186
CVE-2025-61724
CVE-2025-47912
CVE-2025-61729
CVE-2025-58187
CVE-2025-58188
CVE-2025-58189
CVE-2025-61727
CVE-2025-58183
CVE-2025-47910