### PR TITLE
CBP-33001: Security Version Upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM alpine:3.22 AS certs
 
 RUN apk add -U --no-cache ca-certificates
 
-FROM golang:1.25.5-alpine3.22 AS helper
+FROM golang:1.26.0-alpine3.22 AS helper
 
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin
 
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@79ad5557681c631ff7f9391a561609a8452f81c1
 
-FROM golang:1.25.5-alpine3.22 AS build
+FROM golang:1.26.0-alpine3.22 AS build
 
 WORKDIR /work
 


### PR DESCRIPTION
CBP-33001: Upgrade GoLang Version to Latest, Which is 1.26.0 Right Now and Above 1.25.7, Fixes CVE As Per Ticket.

Ignore GitHub ✅ or ❌ , It's Just Synk Tool Status, Not Actual Run, Below is Correct Link.

PreProd Run [Link](https://saas-preprod.beescloud.com/cloudbees-preprod/2c952b88-f84c-4e1e-58cf-d46486aab4bc/components/6f1b749e-bd4b-4576-b7ea-27e7b825650d/runs/de1dac8a-2b59-46dc-84be-58f492295259/117f10d0-83e8-4ee7-a2bb-e16391a10ead/1/logs?componentId=6f1b749e-bd4b-4576-b7ea-27e7b825650d&workflowId=de1dac8a-2b59-46dc-84be-58f492295259&organizationId=2c952b88-f84c-4e1e-58cf-d46486aab4bc)