### PR TITLE
[CBP-45084] Migrate kaniko build to cb-internal-shared-actions/build@v8

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -29,32 +29,18 @@ jobs:
               exit 1
             fi
 
-        - name: Login to AWS
-          uses: cloudbees-io/configure-aws-credentials@v1
-          id: aws-login
+        - id: build
+          name: Build, scan and push to ECR
+          uses: calculi-corp/cb-internal-shared-actions/build@v8
           with:
-            aws-region: us-east-1
-            role-to-assume: ${{ vars.oidc_staging_iam_role }}
-            role-duration-seconds: "3600" # optionally set the duration of the login token
-
-        - name: Configure container registry for Staging ECR
-          uses: https://github.com/cloudbees-io/configure-ecr-credentials@v1
-
-        - name: Build and publish
-          id: build
-          uses: cloudbees-io/kaniko@v1
-          with:
-            destination: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-ecr-credentials:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && ',020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-ecr-credentials:latest' || ''}}
-            labels: maintainer=sdp-pod-3,email=engineering@cloudbees.io
-
-        - id: slsa-attestation
-          name: Generate SLSA attestation
-          uses: calculi-corp/slsa-attestation@v1
-          with:
-            image-digest: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-ecr-credentials@${{ steps.build.outputs.digest }}
-            aws-role-to-assume: ${{ vars.oidc_staging_iam_role }}
-            aws-region: us-east-1
-            aws-kms-alias: cbp-dev-kms-key-cosign          
+            go-binary-build: "true"
+            go-binary-name: configure-ecr-credentials
+            kaniko-build: "true"
+            run-unit-test: "false"
+            registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
+            registry-image-name: actions/configure-ecr-credentials
+            registry-type: ECR
+            oidc-iam-role: ${{ vars.oidc_staging_iam_role }}
 
 
   check:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,23 +9,11 @@ ENV GOBIN=/usr/local/bin
 
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@79ad5557681c631ff7f9391a561609a8452f81c1
 
-FROM golang:1.26.2-alpine3.22 AS build
-
-WORKDIR /work
-
-COPY go.mod* go.sum* ./
-
-RUN go mod download
-
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /build-out/ .
-
 FROM scratch
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=helper /usr/local/bin/docker-credential-* /usr/bin/
-COPY --from=build /build-out/* /usr/bin/
+COPY configure-ecr-credentials /usr/bin/
 
 WORKDIR /cloudbees/home
 


### PR DESCRIPTION
Replace the `kaniko@v1` + AWS/ECR login + `slsa-attestation` pipeline with a single `calculi-corp/cb-internal-shared-actions/build@v8` (services variant) call. Move go build into the workflow via `go-binary-build: true`. Dockerfile slimmed to runtime-only.

Generated by `/upgrade-shared-actions`.

Tracking: CBP-45084 (Upgrade Kaniko and V.x < V8 to shared actions V8: compliance, io).
