### PR TITLE
Bump golang to 1.26.4

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -17,10 +17,10 @@ jobs:
   build:
       steps:
         - name: Checkout
-          uses: cloudbees-io/checkout@v1
+          uses: cloudbees-io/checkout@v2
 
         - name: Validate action
-          uses: docker://amazon/aws-cli:2.27.38
+          uses: docker://amazon/aws-cli:2.35.13
           run: |
             TESTING_SHA=$(cat .cloudbees/testing/action.yml | sha1sum)
             ORIGINAL_SHA=$(sed -e 's|docker://public.ecr.aws/l7o7z1g8/actions/|docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/|g' < action.yml | sha1sum)
@@ -42,7 +42,6 @@ jobs:
             registry-type: ECR
             oidc-iam-role: ${{ vars.oidc_staging_iam_role }}
 
-
   check:
     needs: ["build"]
     steps:
@@ -56,7 +55,7 @@ jobs:
 
       - name: Configure ECR for testing
         uses:  ./.cloudbees/testing
-      - uses: docker://alpine:3.19.1
+      - uses: docker://alpine:3.24
         # We need something that uses ~/.docker/config.json but doesn't need a docker daemon
         # ideally we would just use ghcr.io/regclient/regctl:latest but that is a non-root user
         run: |
@@ -81,7 +80,7 @@ jobs:
         with:
           regions: us-east-1,us-west-2
 
-      - uses: docker://alpine:3.19.1
+      - uses: docker://alpine:3.24
         # We need something that uses ~/.docker/config.json but doesn't need a docker daemon
         # ideally we would just use ghcr.io/regclient/regctl:latest but that is a non-root user
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.22 AS certs
+FROM alpine:3.24 AS certs
 
 RUN apk add -U --no-cache ca-certificates
 
-FROM golang:1.26.2-alpine3.22 AS helper
+FROM golang:1.26.4-alpine3.24 AS helper
 
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin


### PR DESCRIPTION
Should clear up https://cloudbees.atlassian.net/browse/CBP-44315. Also bumps the checkout action to v2 and the AWS CLI to latest.